### PR TITLE
Give warning when vector layer is not multilinestring

### DIFF
--- a/pointtool.py
+++ b/pointtool.py
@@ -1,5 +1,5 @@
 from qgis.core import QgsPointXY, QgsPoint, QgsGeometry, QgsFeature, \
-                      QgsVectorLayer, QgsProject
+                      QgsVectorLayer, QgsProject, QgsWkbTypes
 from qgis.gui import QgsMapToolEmitPoint, QgsMapToolEdit, \
                      QgsRubberBand, QgsVertexMarker, QgsMapTool
 from qgis.PyQt.QtCore import Qt
@@ -25,7 +25,7 @@ class PointTool(QgsMapToolEdit):
         QgsMapTool.deactivate(self)
         self.deactivated.emit()
 
-    def __init__(self, canvas, iface, turn_off_snap, smooth):
+    def __init__(self, canvas, iface, turn_off_snap, smooth=False):
         self.last_mouse_event_pos = None
         self.iface = iface
         self.anchor_points = []
@@ -73,7 +73,14 @@ class PointTool(QgsMapToolEdit):
         try:
             vlayer = self.iface.layerTreeView().selectedLayers()[0]
             if isinstance(vlayer, QgsVectorLayer):
-                return vlayer
+                if  vlayer.wkbType() == QgsWkbTypes.MultiLineString:
+                    return vlayer
+                else:
+                    self.iface.messageBar().pushMessage("The active" +
+                                   " layer must be a MultiLineString vector layer",
+                                          level=Qgis.Warning, duration=2)
+                    return None
+     
             else:
                 self.iface.messageBar().pushMessage("Missing Layer",
                                "Please select vector layer to draw",


### PR DESCRIPTION
Give warning when the active vector layer does no have geometry type MultiLinString.
Fix #7